### PR TITLE
Recursive sp 4

### DIFF
--- a/src/Mastermind.ts
+++ b/src/Mastermind.ts
@@ -167,16 +167,14 @@ export class MastermindZkApp extends SmartContract {
     const solutionHash = Poseidon.hash([...secretCombination, salt]);
     this.solutionHash.set(solutionHash);
 
+    const sender = this.sender.getUnconstrained();
+
     // Generate codeMaster ID & store on-chain
-    const codeMasterId = Poseidon.hash(
-      this.sender.getAndRequireSignature().toFields()
-    );
+    const codeMasterId = Poseidon.hash(sender.toFields());
     this.codeMasterId.set(codeMasterId);
 
     // Get the reward amount from the codeMaster
-    const codeMasterUpdate = AccountUpdate.createSigned(
-      this.sender.getAndRequireSignature()
-    );
+    const codeMasterUpdate = AccountUpdate.createSigned(sender);
     codeMasterUpdate.send({ to: this.address, amount: rewardAmount });
 
     // Update the on-chain reward amount
@@ -211,16 +209,14 @@ export class MastermindZkApp extends SmartContract {
       this.rewardFinalizeSlot.getAndRequireEquals()
     );
 
+    const sender = this.sender.getUnconstrained();
+
     // Transfer the reward amount to the contract from the codeBreaker
-    const codeBreakerUpdate = AccountUpdate.createSigned(
-      this.sender.getAndRequireSignature()
-    );
+    const codeBreakerUpdate = AccountUpdate.createSigned(sender);
     codeBreakerUpdate.send({ to: this.address, amount: rewardAmount });
 
     // generate codeBreaker ID and store on-chain
-    const codeBreakerId = Poseidon.hash(
-      this.sender.getAndRequireSignature().toFields()
-    );
+    const codeBreakerId = Poseidon.hash(sender.toFields());
     this.codeBreakerId.set(codeBreakerId);
 
     const currentSlot =

--- a/src/Mastermind.ts
+++ b/src/Mastermind.ts
@@ -40,7 +40,7 @@ export class MastermindZkApp extends SmartContract {
   /**
    * @returns The balance of the contract.
    */
-  @method.returns(UInt64) async getContractBalance() {
+  async getContractBalance() {
     const accountUpdate = AccountUpdate.create(this.address);
     const tokenBalance = accountUpdate.account.balance.get(); // getAndReqEq ??
     return tokenBalance;
@@ -49,7 +49,7 @@ export class MastermindZkApp extends SmartContract {
   /**
    * Asserts that the game has been finalized. For internal use only.
    */
-  @method async assertFinalized() {
+  async assertFinalized() {
     const currentSlot =
       this.network.globalSlotSinceGenesis.getAndRequireEquals();
     const finalizeSlot = this.finalizeSlot.getAndRequireEquals();

--- a/src/benchmark/benchmark.md
+++ b/src/benchmark/benchmark.md
@@ -24,48 +24,50 @@ This report summarizes the circuit analysis, compilation times, and per-step ben
 
 ### Mastermind Contract Analysis
 
-| Method                 | Rows |
-| ---------------------- | ---- |
-| getContractBalance     | 643  |
-| assertFinalized        | 320  |
-| initGame               | 392  |
-| createGame             | 1819 |
-| acceptGame             | 2096 |
-| submitGameProof        | 553  |
-| claimCodeBreakerReward | 1881 |
-| claimCodeMasterReward  | 1881 |
-| penalizeCodeBreaker    | 1449 |
-| penalizeCodeMaster     | 1449 |
-| makeGuess              | 843  |
-| giveClue               | 985  |
-| **Total**              | 1523 |
+| Method          | Rows |
+| --------------- | ---- |
+| initGame        | 1816 |
+| acceptGame      | 1679 |
+| submitGameProof | 567  |
+| claimReward     | 1079 |
+| forfeitWin      | 1037 |
+| makeGuess       | 857  |
+| giveClue        | 999  |
 
 ### Compilation Times
 
 | Name          | NodeJS Compilation Time | Browser Compilation Time |
 | ------------- | ----------------------- | ------------------------ |
-| stepProgram   | 4.54s                   | 35.08s                   |
-| MastermindApp | 3.23s                   | 25.84s                   |
+| stepProgram   | 13.46s                  | 52.35s                   |
+| MastermindApp | 8.60s                   | 20.67s                   |
 
 ## Step-wise Benchmark Results
 
 ### NodeJS Environment
 
-| Step Length | Solved | Deploy Avg | Initialize Avg | Create Game Avg | Accept Game | Base Proof Avg | Make Guess Avg | Submit Game Proof | Total Time |
-| ----------- | ------ | ---------- | -------------- | --------------- | ----------- | -------------- | -------------- | ----------------- | ---------- |
-| 1           | Yes    | 0.174s     | 10.848s        | 10.433s         | 18.788s     | 9.419s         | 12.334s        | 13.211s           | 87.557s    |
-| 1           | No     | 0.131s     | 9.629s         | 10.072s         | 18.554s     | 8.783s         | 11.916s        | 12.725s           | 83.684s    |
-| 5           | Yes    | 0.131s     | 9.753s         | 10.215s         | 18.514s     | 8.902s         | 12.061s        | 12.993s           | 181.531s   |
-| 5           | No     | 0.129s     | 9.978s         | 10.500s         | 18.841s     | 9.153s         | 12.238s        | 13.160s           | 185.164s   |
-| 10          | Yes    | 0.129s     | 9.861s         | 10.814s         | 19.169s     | 9.117s         | 12.547s        | 13.360s           | 313.796s   |
-| 10          | No     | 0.130s     | 10.436s        | 10.805s         | 19.408s     | 9.601s         | 12.564s        | 13.502s           | 315.940s   |
-| 15          | Yes    | 0.129s     | 10.474s        | 10.800s         | 19.533s     | 9.360s         | 12.646s        | 13.484s           | 443.163s   |
-| 15          | No     | 0.129s     | 10.379s        | 11.038s         | 19.543s     | 9.643s         | 12.633s        | 13.379s           | 443.924s   |
+| Step Length | Solved | Deploy & Initialize Avg | Accept Game | Base Proof Avg | Make Guess Avg | Submit Game Proof | Total Time |
+| ----------- | ------ | ----------------------- | ----------- | -------------- | -------------- | ----------------- | ---------- |
+| 1           | Yes    | 11.402                  | 10.337      | 9.499          | 12.358         | 13.209            | 69.454     |
+| 1           | No     | 10.370                  | 10.057      | 8.801          | 11.943         | 12.634            | 65.731     |
+| 5           | Yes    | 10.340                  | 10.128      | 8.807          | 12.352         | 13.348            | 168.026    |
+| 5           | No     | 11.108                  | 10.304      | 8.897          | 12.173         | 13.270            | 166.189    |
+| 10          | Yes    | 10.519                  | 10.470      | 9.617          | 12.601         | 12.987            | 295.009    |
+| 10          | No     | 10.586                  | 10.502      | 9.149          | 12.598         | 13.675            | 295.294    |
+| 15          | Yes    | 10.811                  | 10.649      | 9.303          | 12.646         | 13.621            | 424.020    |
+| 15          | No     | 10.861                  | 10.875      | 9.570          | 12.737         | 13.529            | 428.026    |
 
 ### Browser Environment
 
-| Step Length | Solved | Deploy Avg | Initialize Avg | Create Game Avg | Accept Game | Base Proof Avg | Make Guess Avg | Submit Game Proof | Total Time |
-| ----------- | ------ | ---------- | -------------- | --------------- | ----------- | -------------- | -------------- | ----------------- | ---------- |
+| Step Length | Solved | Deploy & Initialize Avg | Accept Game | Base Proof Avg | Make Guess Avg | Submit Game Proof | Total Time |
+| ----------- | ------ | ----------------------- | ----------- | -------------- | -------------- | ----------------- | ---------- |
+| 1           | Yes    | 16.305                  | 16.150      | 14.438         | 19.069         | 20.441            | 105.603    |
+| 1           | No     | 15.127                  | 16.124      | 14.212         | 18.696         | 19.615            | 102.495    |
+| 5           | Yes    | 15.392                  | 16.020      | 14.165         | 19.128         | 19.915            | 255.936    |
+| 5           | No     | 15.498                  | 15.469      | 14.328         | 18.731         | 19.829            | 251.549    |
+| 10          | Yes    | 16.176                  | 16.263      | 14.728         | 19.225         | 20.256            | 452.371    |
+| 10          | No     | 16.576                  | 16.150      | 14.511         | 19.380         | 21.340            | 455.191    |
+| 15          | Yes    | 16.126                  | 16.339      | 14.449         | 19.161         | 20.634            | 644.687    |
+| 15          | No     | 15.644                  | 16.475      | 14.312         | 19.634         | 20.800            | 655.678    |
 
 ## Overall Scores
 
@@ -73,31 +75,38 @@ This report summarizes the circuit analysis, compilation times, and per-step ben
 
 | Metric                        | Solved Games | Unsolved Games |
 | ----------------------------- | ------------ | -------------- |
-| Avg Time Each Game Step       | 33.0983s     | 33.1842s       |
-| Avg Deploy Time               | 0.1407s      | 0.1297s        |
-| Avg Initialize Game Time      | 10.2341s     | 10.1058s       |
-| Avg Create Game Time          | 9.1996s      | 9.2949s        |
-| Avg Accept Game Time          | 19.0009s     | 19.0864s       |
-| Avg Time To Create Base Proof | 9.1996s      | 9.2949s        |
-| Avg Make Guess Time           | 12.5099s     | 12.5236s       |
-| Avg Give Clue Time            | 12.5364s     | 12.6074s       |
-| Avg Submit Game Proof Time    | 13.2621s     | 13.1916s       |
+| Avg Time Each Game Step       | 30.8551s     | 30.8142s       |
+| Avg Deploy & Initialize Time  | 10.7679s     | 10.7310s       |
+| Avg Accept Game Time          | 10.3959s     | 10.4348s       |
+| Avg Time To Create Base Proof | 9.3065s      | 9.1043s        |
+| Avg Make Guess Time           | 12.5747s     | 12.5758s       |
+| Avg Give Clue Time            | 12.6337s     | 12.6194s       |
+| Avg Submit Game Proof Time    | 13.2914s     | 13.2770s       |
 
 ### Browser Environment
 
-| Metric | Solved Games | Unsolved Games |
-| ------ | ------------ | -------------- |
+| Metric                        | Solved Games | Unsolved Games |
+| ----------------------------- | ------------ | -------------- |
+| Avg Time Each Game Step       | 47.0515s     | 47.2552s       |
+| Avg Deploy & Initialize Time  | 15.9994s     | 15.7113s       |
+| Avg Accept Game Time          | 16.1931s     | 16.0547s       |
+| Avg Time To Create Base Proof | 14.4447s     | 14.3406s       |
+| Avg Make Guess Time           | 19.1733s     | 19.3762s       |
+| Avg Give Clue Time            | 19.2396s     | 19.2980s       |
+| Avg Submit Game Proof Time    | 20.3118s     | 20.3959s       |
 
 #### Metric Explanations
 
 - **Avg Time Each Game Step**: Total time taken to complete a game step on average.
-- **Avg Time To Create Base Proof**: Average time taken to create a game proof. Single base proof created on every game.
-- **Avg Make Guess Time**: Average time taken to make a guess in the game, based on measured from multiple games with different steps.
-- **Avg Give Clue Time**: Average time taken to give a clue in the game, based on measured from multiple games with different steps.
-- **Avg Submit Game Proof Time**: Average time taken to create transaction proof and submit it to the local network (Block creation time not included).
+- **Avg Deploy & Initialize Time**: Time taken to deploy and initialize the contract.
+- **Avg Accept Game Time**: Time taken to accept a game by code breaker.
+- **Avg Time To Create Base Proof**: Time taken to create the base proof for recursion.
+- **Avg Make Guess Time**: Time taken to make a guess by code breaker.
+- **Avg Give Clue Time**: Time taken to give a clue by code master.
+- **Avg Submit Game Proof Time**: Time taken to submit the recursive game proof to on-chain.
 
 # Conclusion
 
 Unlike the fully on-chain approach where the game state is stored and changed on-chain in every step, the recursive MastermindZkApp approach allows for both parties to interact with each other off-chain and only submit the final succint proof to the chain that includes all the game steps and the result. This approach significantly reduces the on-chain block time waiting and the cost of transactions.
 
-Mina's block time is around 3 minutes, and that means without recursion it would take at least 6 minutes to complete a game step (making guess and giving clue). With the recursive approach, the time is reduced to around 27 seconds on average. This improvement is reach significant levels when the game steps increase.
+Mina's block time is around 3 minutes, and that means without recursion it would take at least 6 minutes to complete a game step (making guess and giving clue). With the recursive approach, the time is reduced to around 47 seconds on average. This improvement is reach significant levels when the game steps increase.

--- a/src/benchmark/browser/app/page.tsx
+++ b/src/benchmark/browser/app/page.tsx
@@ -1,34 +1,10 @@
 'use client';
 import { useEffect } from 'react';
-import { type PrivateKey, type Field } from 'o1js';
-import { StepProgramProof } from '../../../../build/src/stepProgram';
-
-interface BenchmarkResults {
-  stepLength: number;
-  totalSeconds: number;
-  deploySeconds: number;
-  initializeGameSeconds: number;
-  acceptGameSeconds: number;
-  baseGameSeconds: number;
-  makeGuessSeconds: number[];
-  giveClueSeconds: number[];
-  isSolved: boolean;
-  submitGameProofSeconds: number;
-}
+import WorkerClient from './worker/workerClient';
 
 export default function Home() {
   useEffect(() => {
     (async () => {
-      const { Mina, PrivateKey, AccountUpdate, Field, Signature, UInt64 } =
-        await import('o1js');
-      const { MastermindZkApp } = await import(
-        '../../../../build/src/Mastermind'
-      );
-      const { StepProgram } = await import('../../../../build/src/stepProgram');
-      const { checkIfSolved, deserializeClue } = await import(
-        '../../../../build/src/utils'
-      );
-
       const updateProgress = (msg: string): void => {
         let progressElem = document.getElementById('progress');
         if (!progressElem) {
@@ -37,9 +13,8 @@ export default function Home() {
           const container = document.getElementById('logs');
           if (container) container.appendChild(progressElem);
         }
-
         const currentTime = new Date().toLocaleTimeString();
-        progressElem.textContent = msg + ' - ' + currentTime;
+        progressElem.textContent = `${msg} - ${currentTime}`;
       };
 
       const appendFinalLog = (msg: string): void => {
@@ -51,24 +26,18 @@ export default function Home() {
       };
 
       const prettifyBenchmark = (result: BenchmarkResults) => {
-        const avgCreateGame = result.baseGameSeconds;
         const avgMakeGuess = result.makeGuessSeconds.length
           ? result.makeGuessSeconds.reduce((a, b) => a + b, 0) /
             result.makeGuessSeconds.length
           : 0;
-
+        const avgCreateGame = result.baseGameSeconds;
         appendFinalLog(`Step Length: ${result.stepLength}`);
         appendFinalLog(`Total Seconds: ${result.totalSeconds.toFixed(3)}`);
-        appendFinalLog(`Deploy (Avg): ${result.deploySeconds.toFixed(3)}`);
         appendFinalLog(
-          `Initialize Game (Avg): ${result.initializeGameSeconds.toFixed(3)}`
+          `Deploy & Initialize: ${result.deployAndInitializeSeconds.toFixed(3)}`
         );
-        appendFinalLog(
-          `Accept Game (Avg): ${result.acceptGameSeconds.toFixed(3)}`
-        );
-        appendFinalLog(
-          `Base Game Proof Create  (Avg): ${avgCreateGame.toFixed(3)}`
-        );
+        appendFinalLog(`Accept Game: ${result.acceptGameSeconds.toFixed(3)}`);
+        appendFinalLog(`Base Game Proof Create: ${avgCreateGame.toFixed(3)}`);
         appendFinalLog(`Make Guess (Avg): ${avgMakeGuess.toFixed(3)}`);
         appendFinalLog(`Solved: ${result.isSolved ? 'Yes' : 'No'}`);
         appendFinalLog(
@@ -88,11 +57,7 @@ export default function Home() {
           0
         );
         const totalDeploy = benchmarkResults.reduce(
-          (sum, result) => sum + result.deploySeconds,
-          0
-        );
-        const totalInitializeGame = benchmarkResults.reduce(
-          (sum, result) => sum + result.initializeGameSeconds,
+          (sum, result) => sum + result.deployAndInitializeSeconds,
           0
         );
         const totalAcceptGame = benchmarkResults.reduce(
@@ -124,11 +89,6 @@ export default function Home() {
           `Avg Time To Deploy: ${totalDeploy / totalBenchmarkResults}`
         );
         appendFinalLog(
-          `Avg Time To Initialize Game: ${
-            totalInitializeGame / totalBenchmarkResults
-          }`
-        );
-        appendFinalLog(
           `Avg Time To Accept Game: ${totalAcceptGame / totalBenchmarkResults}`
         );
         appendFinalLog(
@@ -150,279 +110,88 @@ export default function Home() {
         appendFinalLog('--------------------------------------');
       };
 
-      updateProgress('Compiling zkApp and StepProgram...');
-      let compileStart = performance.now();
-      await StepProgram.compile();
-      let compileEnd = performance.now();
-      appendFinalLog('--------------------------------------');
+      updateProgress('Initializing Worker...');
+      const workerClient = new WorkerClient();
+
+      // wait for worker to be ready 5 seconds
+      await new Promise((resolve) => setTimeout(resolve, 5000));
+
+      updateProgress('Compiling program...');
+      let start = performance.now();
+      await workerClient.compileProgram();
+      let end = performance.now();
+      appendFinalLog(`Compiling program took ${(end - start) / 1000} seconds`);
+
+      updateProgress('Loading and compiling contract...');
+      start = performance.now();
+      await workerClient.loadAndCompileContract();
+      end = performance.now();
       appendFinalLog(
-        `StepProgram compilation took ${
-          (compileEnd - compileStart) / 1000
-        } seconds`
+        `Loading and compiling contract took ${(end - start) / 1000} seconds`
       );
 
-      compileStart = performance.now();
-      await MastermindZkApp.compile();
-      compileEnd = performance.now();
-      appendFinalLog(
-        `MastermindZkApp compilation took ${
-          (compileEnd - compileStart) / 1000
-        } seconds`
-      );
-      appendFinalLog('--------------------------------------');
-
-      async function localDeploy(
-        zkapp: InstanceType<typeof MastermindZkApp>,
-        deployerKey: PrivateKey,
-        zkappPrivateKey: PrivateKey
-      ): Promise<void> {
-        const deployerAccount = deployerKey.toPublicKey();
-        const tx = await Mina.transaction(deployerAccount, async () => {
-          AccountUpdate.fundNewAccount(deployerAccount);
-          zkapp.deploy();
-        });
-        await tx.prove();
-        await tx.sign([deployerKey, zkappPrivateKey]).send();
-      }
-
-      async function initializeGame(
-        zkapp: InstanceType<typeof MastermindZkApp>,
-        codeMasterKey: PrivateKey,
-        codeMasterSalt: Field,
-        unseparatedSecretCombination: Field,
-        refereeKey: PrivateKey,
-        maxAttempt: Field
-      ): Promise<void> {
-        const deployerAccount = codeMasterKey.toPublicKey();
-        const refereeAccount = refereeKey.toPublicKey();
-
-        const initTx = await Mina.transaction(deployerAccount, async () => {
-          await zkapp.initGame(
-            unseparatedSecretCombination,
-            codeMasterSalt,
-            maxAttempt,
-            refereeAccount,
-            UInt64.from(10000)
-          );
-        });
-
-        await initTx.prove();
-        await initTx.sign([codeMasterKey]).send();
-      }
-
-      async function acceptGame(
-        zkapp: InstanceType<typeof MastermindZkApp>,
-        codeBreakerKey: PrivateKey
-      ) {
-        const codeBreakerPubKey = codeBreakerKey.toPublicKey();
-        const tx = await Mina.transaction(codeBreakerPubKey, async () => {
-          await zkapp.acceptGame();
-        });
-
-        await tx.prove();
-        await tx.sign([codeBreakerKey]).send();
-      }
-
-      async function solveBenchmark(
-        secret: number,
-        steps: Field[]
-      ): Promise<BenchmarkResults> {
-        const Local = await Mina.LocalBlockchain();
-        Mina.setActiveInstance(Local);
-
-        const codeMasterKey: PrivateKey = Local.testAccounts[0].key;
-        const codeMasterPubKey = codeMasterKey.toPublicKey();
-        const codeMasterSalt: Field = Field.random();
-
-        const codeBreakerKey: PrivateKey = Local.testAccounts[1].key;
-        const codeBreakerPubKey = codeBreakerKey.toPublicKey();
-
-        const refereeKey = Local.testAccounts[2].key;
-
-        const zkappPrivateKey: PrivateKey = PrivateKey.random();
-        const zkappAddress = zkappPrivateKey.toPublicKey();
-        const zkapp = new MastermindZkApp(zkappAddress);
-        const unseparatedSecretCombination: Field = Field.from(secret);
-        let lastProof: StepProgramProof;
-
-        const currentBenchmarkResults: BenchmarkResults = {
-          stepLength: steps.length,
-          totalSeconds: 0,
-          deploySeconds: 0,
-          initializeGameSeconds: 0,
-          acceptGameSeconds: 0,
-          baseGameSeconds: 0,
-          makeGuessSeconds: [],
-          giveClueSeconds: [],
-          isSolved: false,
-          submitGameProofSeconds: 0,
-        };
-
-        updateProgress('Deploying zkApp...');
-        let start = performance.now();
-        await localDeploy(zkapp, codeMasterKey, zkappPrivateKey);
-        let end = performance.now();
-        currentBenchmarkResults.deploySeconds = (end - start) / 1000;
-
-        updateProgress('Initializing game...');
-        start = performance.now();
-        await initializeGame(
-          zkapp,
-          codeMasterKey,
-          codeMasterSalt,
-          unseparatedSecretCombination,
-          refereeKey,
-          Field.from(15)
-        );
-        end = performance.now();
-        currentBenchmarkResults.initializeGameSeconds = (end - start) / 1000;
-
-        updateProgress('Accepting game...');
-        start = performance.now();
-        await acceptGame(zkapp, codeBreakerKey);
-        end = performance.now();
-        currentBenchmarkResults.acceptGameSeconds = (end - start) / 1000;
-
-        updateProgress('Generating base proof (createGame)...');
-        start = performance.now();
-        lastProof = (
-          await StepProgram.createGame(
-            {
-              authPubKey: codeMasterPubKey,
-              authSignature: Signature.create(codeMasterKey, [
-                unseparatedSecretCombination,
-                codeMasterSalt,
-              ]),
-            },
-            unseparatedSecretCombination,
-            codeMasterSalt
-          )
-        ).proof;
-        end = performance.now();
-
-        currentBenchmarkResults.baseGameSeconds = (end - start) / 1000;
-
-        for (const step of steps) {
-          updateProgress(`Processing makeGuess for step ${step.toString()}...`);
-          start = performance.now();
-          lastProof = (
-            await StepProgram.makeGuess(
-              {
-                authPubKey: codeBreakerPubKey,
-                authSignature: Signature.create(codeBreakerKey, [
-                  step,
-                  lastProof.publicOutput.turnCount,
-                ]),
-              },
-              lastProof,
-              step
-            )
-          ).proof;
-          end = performance.now();
-          currentBenchmarkResults.makeGuessSeconds.push((end - start) / 1000);
-
-          updateProgress(`Processing giveClue for step ${step.toString()}...`);
-          start = performance.now();
-          lastProof = (
-            await StepProgram.giveClue(
-              {
-                authPubKey: codeMasterPubKey,
-                authSignature: Signature.create(codeMasterKey, [
-                  unseparatedSecretCombination,
-                  codeMasterSalt,
-                  lastProof.publicOutput.turnCount,
-                ]),
-              },
-              lastProof,
-              unseparatedSecretCombination,
-              codeMasterSalt
-            )
-          ).proof;
-          end = performance.now();
-          currentBenchmarkResults.giveClueSeconds.push((end - start) / 1000);
-        }
-
-        updateProgress('Submitting game proof...');
-        start = performance.now();
-        const submitGameProofTx = await Mina.transaction(
-          codeBreakerKey.toPublicKey(),
-          async () => {
-            await zkapp.submitGameProof(lastProof);
-          }
-        );
-
-        await submitGameProofTx.prove();
-        await submitGameProofTx.sign([codeBreakerKey]).send();
-        end = performance.now();
-
-        const deserializedClue = deserializeClue(
-          lastProof.publicOutput.serializedClue
-        );
-        const isSolved = checkIfSolved(deserializedClue);
-
-        currentBenchmarkResults.isSolved = isSolved.toBoolean();
-
-        currentBenchmarkResults.submitGameProofSeconds = (end - start) / 1000;
-
-        currentBenchmarkResults.totalSeconds =
-          currentBenchmarkResults.deploySeconds +
-          currentBenchmarkResults.initializeGameSeconds +
-          currentBenchmarkResults.acceptGameSeconds +
-          currentBenchmarkResults.baseGameSeconds +
-          currentBenchmarkResults.makeGuessSeconds.reduce((a, b) => a + b, 0) +
-          currentBenchmarkResults.giveClueSeconds.reduce((a, b) => a + b, 0) +
-          currentBenchmarkResults.submitGameProofSeconds;
-
-        prettifyBenchmark(currentBenchmarkResults);
-
-        return currentBenchmarkResults;
-      }
-
-      const steps: Field[] = [
-        Field.from(9312),
-        Field.from(3456),
-        Field.from(7891),
-        Field.from(2345),
-        Field.from(6789),
-        Field.from(5432),
-        Field.from(9786),
-        Field.from(8461),
-        Field.from(6532),
-        Field.from(5316),
-        Field.from(7451),
-        Field.from(9123),
-        Field.from(4567),
-        Field.from(8951),
-        Field.from(1234),
+      const steps: number[] = [
+        9312, 3456, 7891, 2345, 6789, 5432, 9786, 8461, 6532, 5316, 7451, 9123,
+        4567, 8951, 1234,
       ];
 
       const benchmarkResults: BenchmarkResults[] = [];
 
-      // Step length 1
+      updateProgress('Running benchmark for step length 1...');
+      let result = await workerClient.solveBenchmark({
+        secretCombination: [1, 2, 3, 4],
+        steps: steps.slice(14),
+      });
+      benchmarkResults.push(result);
+      prettifyBenchmark(result);
+      result = await workerClient.solveBenchmark({
+        secretCombination: [4, 3, 2, 1],
+        steps: steps.slice(14),
+      });
+      benchmarkResults.push(result);
+      prettifyBenchmark(result);
 
-      let result = await solveBenchmark(1234, steps.slice(14));
+      updateProgress('Running benchmark for step length 5...');
+      result = await workerClient.solveBenchmark({
+        secretCombination: [1, 2, 3, 4],
+        steps: steps.slice(10),
+      });
       benchmarkResults.push(result);
-      result = await solveBenchmark(4321, steps.slice(14));
+      prettifyBenchmark(result);
+      result = await workerClient.solveBenchmark({
+        secretCombination: [4, 3, 2, 1],
+        steps: steps.slice(10),
+      });
       benchmarkResults.push(result);
+      prettifyBenchmark(result);
 
-      // Step length 5
+      updateProgress('Running benchmark for step length 10...');
+      result = await workerClient.solveBenchmark({
+        secretCombination: [1, 2, 3, 4],
+        steps: steps.slice(5),
+      });
+      benchmarkResults.push(result);
+      prettifyBenchmark(result);
+      result = await workerClient.solveBenchmark({
+        secretCombination: [4, 3, 2, 1],
+        steps: steps.slice(5),
+      });
+      benchmarkResults.push(result);
+      prettifyBenchmark(result);
 
-      result = await solveBenchmark(1234, steps.slice(10));
+      updateProgress('Running benchmark for step length 15...');
+      result = await workerClient.solveBenchmark({
+        secretCombination: [1, 2, 3, 4],
+        steps: steps,
+      });
       benchmarkResults.push(result);
-      result = await solveBenchmark(4321, steps.slice(10));
+      prettifyBenchmark(result);
+      result = await workerClient.solveBenchmark({
+        secretCombination: [4, 3, 2, 1],
+        steps: steps,
+      });
       benchmarkResults.push(result);
-
-      // Step length 10
-      result = await solveBenchmark(1234, steps.slice(5));
-      benchmarkResults.push(result);
-      result = await solveBenchmark(4321, steps.slice(5));
-      benchmarkResults.push(result);
-
-      // Step length 15
-      result = await solveBenchmark(1234, steps);
-      benchmarkResults.push(result);
-      result = await solveBenchmark(4321, steps);
-      benchmarkResults.push(result);
+      prettifyBenchmark(result);
 
       const progressElem = document.getElementById('progress');
       if (progressElem && progressElem.parentNode) {
@@ -438,7 +207,7 @@ export default function Home() {
 
   return (
     <main>
-      <h1>Mastermind Browser Benchmark</h1>
+      <h1>Mastermind Browser Benchmark (Worker)</h1>
       <div
         id="logs"
         style={{ whiteSpace: 'pre-wrap', fontFamily: 'monospace' }}

--- a/src/benchmark/browser/app/types.d.ts
+++ b/src/benchmark/browser/app/types.d.ts
@@ -1,0 +1,11 @@
+interface BenchmarkResults {
+  stepLength: number;
+  totalSeconds: number;
+  deployAndInitializeSeconds: number;
+  acceptGameSeconds: number;
+  baseGameSeconds: number;
+  makeGuessSeconds: number[];
+  giveClueSeconds: number[];
+  isSolved: boolean;
+  submitGameProofSeconds: number;
+}

--- a/src/benchmark/browser/app/worker/worker.ts
+++ b/src/benchmark/browser/app/worker/worker.ts
@@ -1,0 +1,256 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import 'reflect-metadata';
+import {
+  Field,
+  AccountUpdate,
+  UInt64,
+  PublicKey,
+  Mina,
+  PrivateKey,
+  Signature,
+} from 'o1js';
+import { StepProgram } from '../../../../../build/src/stepProgram';
+import { MastermindZkApp } from '../../../../../build/src/Mastermind';
+import {
+  checkIfSolved,
+  compressCombinationDigits,
+  deserializeClue,
+} from '../../../../../build/src/utils';
+
+const state = {
+  StepProgram: null as typeof StepProgram | null,
+  MastermindContract: null as typeof MastermindZkApp | null,
+  MastermindInstance: null as MastermindZkApp | null,
+  codeMasterKey: null as PrivateKey | null,
+  codeMasterPubKey: null as PublicKey | null,
+  codeMasterSalt: null as Field | null,
+  codeBreakerKey: null as PrivateKey | null,
+  codeBreakerPubKey: null as PublicKey | null,
+  refereeKey: null as PrivateKey | null,
+  zkappPrivateKey: null as PrivateKey | null,
+  zkappAddress: null as PublicKey | null,
+  zkapp: null as InstanceType<typeof MastermindZkApp> | null,
+  secretCombination: null as number[] | null,
+  unseparatedSecretCombination: null as Field | null,
+  benchmarkResults: null as BenchmarkResults | null,
+};
+export type State = typeof state;
+
+const functions = {
+  setActiveInstanceToLocal: async ({
+    secretCombination,
+  }: {
+    secretCombination: number[];
+  }) => {
+    const Local = await Mina.LocalBlockchain();
+    console.log('Devnet network instance configured.');
+    Mina.setActiveInstance(Local);
+
+    state.codeMasterKey = Local.testAccounts[0].key;
+    state.codeMasterPubKey = state.codeMasterKey.toPublicKey();
+    state.codeMasterSalt = Field.random();
+    state.codeBreakerKey = Local.testAccounts[1].key;
+    state.codeBreakerPubKey = state.codeBreakerKey.toPublicKey();
+    state.refereeKey = Local.testAccounts[2].key;
+    state.zkappPrivateKey = PrivateKey.random();
+    state.zkappAddress = state.zkappPrivateKey.toPublicKey();
+    state.zkapp = new MastermindZkApp(state.zkappAddress);
+    state.secretCombination = secretCombination;
+    state.unseparatedSecretCombination = compressCombinationDigits(
+      state.secretCombination.map(Field)
+    );
+    state.benchmarkResults = {
+      stepLength: 0,
+      totalSeconds: 0,
+      deployAndInitializeSeconds: 0,
+      acceptGameSeconds: 0,
+      baseGameSeconds: 0,
+      makeGuessSeconds: [],
+      giveClueSeconds: [],
+      isSolved: false,
+      submitGameProofSeconds: 0,
+    };
+  },
+  loadAndCompileContract: async () => {
+    if (!state.MastermindContract) {
+      const { MastermindZkApp } = await import(
+        '../../../../../build/src/Mastermind.js'
+      );
+      if (!MastermindZkApp) {
+        throw new Error(`Could not load contract GameToken from the module`);
+      }
+      state.MastermindContract = MastermindZkApp;
+    }
+    await state.MastermindContract.compile();
+  },
+  compileProgram: async () => {
+    state.StepProgram = StepProgram;
+    await state.StepProgram.compile();
+  },
+
+  deployAndInitializeContract: async () => {
+    const deployerAccount = state.codeMasterPubKey!;
+    const tx = await Mina.transaction(deployerAccount, async () => {
+      AccountUpdate.fundNewAccount(deployerAccount);
+      state.zkapp!.deploy();
+      await state.zkapp!.initGame(
+        state.unseparatedSecretCombination!,
+        state.codeMasterSalt!,
+        Field.from(10),
+        state.refereeKey!.toPublicKey(),
+        UInt64.from(10000)
+      );
+    });
+    await tx.prove();
+    await tx.sign([state.codeMasterKey!, state.zkappPrivateKey!]).send();
+  },
+
+  acceptGame: async () => {
+    const tx = await Mina.transaction(state.codeBreakerPubKey!, async () => {
+      await state.zkapp!.acceptGame();
+    });
+    await tx.prove();
+    await tx.sign([state.codeBreakerKey!]).send();
+  },
+
+  solveBenchmark: async ({
+    secretCombination,
+    steps,
+  }: {
+    secretCombination: number[];
+    steps: number[];
+  }) => {
+    console.log('Initiating Local Mina');
+    await functions.setActiveInstanceToLocal({ secretCombination });
+    if (!state.benchmarkResults) {
+      throw new Error('Benchmark results not initialized');
+    }
+    state.benchmarkResults.stepLength = steps.length;
+
+    console.log('Deploying and Initializing Contract');
+    let start = performance.now();
+    await functions.deployAndInitializeContract();
+    let end = performance.now();
+    state.benchmarkResults.deployAndInitializeSeconds = (end - start) / 1000;
+
+    console.log('Accepting Game');
+    start = performance.now();
+    await functions.acceptGame();
+    end = performance.now();
+    state.benchmarkResults.acceptGameSeconds = (end - start) / 1000;
+
+    console.log('Base Game');
+    start = performance.now();
+    let { proof } = await StepProgram.createGame(
+      {
+        authPubKey: state.codeMasterPubKey!,
+        authSignature: Signature.create(state.codeMasterKey!, [
+          state.unseparatedSecretCombination!,
+          state.codeMasterSalt!,
+        ]),
+      },
+      state.unseparatedSecretCombination!,
+      state.codeMasterSalt!
+    );
+    end = performance.now();
+    state.benchmarkResults.baseGameSeconds = (end - start) / 1000;
+
+    for (const step of steps) {
+      console.log(`Processing step ${step.toString()}...`);
+      start = performance.now();
+      proof = (
+        await StepProgram.makeGuess(
+          {
+            authPubKey: state.codeBreakerPubKey!,
+            authSignature: Signature.create(state.codeBreakerKey!, [
+              Field.from(step),
+              proof.publicOutput.turnCount,
+            ]),
+          },
+          proof,
+          Field.from(step)
+        )
+      ).proof;
+      end = performance.now();
+      state.benchmarkResults.makeGuessSeconds.push((end - start) / 1000);
+
+      console.log(`Giving clue for step ${step.toString()}...`);
+      start = performance.now();
+      proof = (
+        await StepProgram.giveClue(
+          {
+            authPubKey: state.codeMasterPubKey!,
+            authSignature: Signature.create(state.codeMasterKey!, [
+              state.unseparatedSecretCombination!,
+              state.codeMasterSalt!,
+              proof.publicOutput.turnCount,
+            ]),
+          },
+          proof,
+          state.unseparatedSecretCombination!,
+          state.codeMasterSalt!
+        )
+      ).proof;
+      end = performance.now();
+      state.benchmarkResults.giveClueSeconds.push((end - start) / 1000);
+    }
+
+    console.log('Submitting Game Proof');
+    start = performance.now();
+    const submitGameProofTx = await Mina.transaction(
+      state.codeBreakerKey!.toPublicKey(),
+      async () => {
+        await state.zkapp!.submitGameProof(proof);
+      }
+    );
+
+    await submitGameProofTx.prove();
+    await submitGameProofTx.sign([state.codeBreakerKey!]).send();
+    end = performance.now();
+    state.benchmarkResults.submitGameProofSeconds = (end - start) / 1000;
+
+    const deserializedClue = deserializeClue(proof.publicOutput.serializedClue);
+    const isSolved = checkIfSolved(deserializedClue);
+
+    state.benchmarkResults.isSolved = isSolved.toBoolean();
+
+    state.benchmarkResults.totalSeconds =
+      state.benchmarkResults.deployAndInitializeSeconds +
+      state.benchmarkResults.acceptGameSeconds +
+      state.benchmarkResults.baseGameSeconds +
+      state.benchmarkResults.makeGuessSeconds.reduce((a, b) => a + b, 0) +
+      state.benchmarkResults.giveClueSeconds.reduce((a, b) => a + b, 0) +
+      state.benchmarkResults.submitGameProofSeconds;
+
+    return state.benchmarkResults;
+  },
+};
+export type WorkerFunctions = keyof typeof functions;
+
+export type ZkappWorkerRequest = {
+  id: number;
+  fn: WorkerFunctions;
+  args: any;
+};
+
+export type ZkappWorkerReponse = {
+  id: number;
+  data: any;
+};
+
+if (typeof window !== 'undefined') {
+  addEventListener(
+    'message',
+    async (event: MessageEvent<ZkappWorkerRequest>) => {
+      const returnData = await functions[event.data.fn](event.data.args);
+
+      const message: ZkappWorkerReponse = {
+        id: event.data.id,
+        data: returnData,
+      };
+      postMessage(message);
+    }
+  );
+}
+
+console.log('Web Worker Successfully Initialized.');

--- a/src/benchmark/browser/app/worker/workerClient.ts
+++ b/src/benchmark/browser/app/worker/workerClient.ts
@@ -1,0 +1,75 @@
+import type {
+  ZkappWorkerRequest,
+  ZkappWorkerReponse,
+  WorkerFunctions,
+} from './worker.js';
+
+export default class WorkerClient {
+  setActiveInstanceToLocal() {
+    return this._call('setActiveInstanceToLocal', {});
+  }
+
+  loadAndCompileContract() {
+    return this._call('loadAndCompileContract', {});
+  }
+
+  compileProgram() {
+    return this._call('compileProgram', {});
+  }
+
+  deployAndInitializeContract() {
+    return this._call('deployAndInitializeContract', {});
+  }
+
+  acceptGame() {
+    return this._call('acceptGame', {});
+  }
+
+  solveBenchmark({
+    secretCombination,
+    steps,
+  }: {
+    secretCombination: number[];
+    steps: number[];
+  }): Promise<BenchmarkResults> {
+    return this._call('solveBenchmark', {
+      secretCombination,
+      steps,
+    }) as Promise<BenchmarkResults>;
+  }
+
+  worker: Worker;
+
+  promises: {
+    [id: number]: { resolve: (res: any) => void; reject: (err: any) => void };
+  };
+
+  nextId: number;
+
+  constructor() {
+    this.worker = new Worker(new URL('./worker.ts', import.meta.url));
+    this.promises = {};
+    this.nextId = 0;
+
+    this.worker.onmessage = (event: MessageEvent<ZkappWorkerReponse>) => {
+      this.promises[event.data.id].resolve(event.data.data);
+      delete this.promises[event.data.id];
+    };
+  }
+
+  _call(fn: WorkerFunctions, args: any) {
+    return new Promise((resolve, reject) => {
+      this.promises[this.nextId] = { resolve, reject };
+
+      const message: ZkappWorkerRequest = {
+        id: this.nextId,
+        fn,
+        args,
+      };
+
+      this.worker.postMessage(message);
+
+      this.nextId++;
+    });
+  }
+}

--- a/src/benchmark/node/benchmark.ts
+++ b/src/benchmark/node/benchmark.ts
@@ -144,10 +144,6 @@ function overallScores(benchmarkResults: BenchmarkResults[]) {
       Value: totalDeploy / totalBenchmarkResults,
     },
     {
-      Metric: 'Avg Create Game Time',
-      Value: totalCreateGame / totalBenchmarkResults,
-    },
-    {
       Metric: 'Avg Accept Game Time',
       Value: totalAcceptGame / totalBenchmarkResults,
     },

--- a/src/test/stepProgram.test.ts
+++ b/src/test/stepProgram.test.ts
@@ -7,19 +7,27 @@ import {
 import { StepProgram, StepProgramProof } from '../stepProgram';
 
 describe('Mastermind ZkProgram Tests', () => {
-  let codeMasterKey: PrivateKey,
-    codeMasterPubKey: PublicKey,
-    codeMasterSalt: Field,
-    codeMasterId: Field,
-    codeBreakerKey: PrivateKey,
-    codeBreakerPubKey: PublicKey,
-    codeBreakerId: Field,
-    unseparatedSecretCombination: Field,
-    lastProof: StepProgramProof;
+  // Global variables
+  let codeMasterKey: PrivateKey;
+  let codeMasterPubKey: PublicKey;
+  let codeMasterSalt: Field;
+  let codeMasterId: Field;
+
+  let codeBreakerKey: PrivateKey;
+  let codeBreakerPubKey: PublicKey;
+  let codeBreakerId: Field;
+
+  // Compressed secret combination for codeMaster
+  let unseparatedSecretCombination: Field;
+
+  // Hold the last proof we produced
+  let lastProof: StepProgramProof;
 
   beforeAll(async () => {
+    // Compile the ZkProgram before tests
     await StepProgram.compile();
 
+    // Create codeMaster keys & derive ID
     codeMasterKey = PrivateKey.random();
     codeMasterPubKey = codeMasterKey.toPublicKey();
     codeMasterId = Poseidon.hash(codeMasterPubKey.toFields());
@@ -30,11 +38,12 @@ describe('Mastermind ZkProgram Tests', () => {
     // Generate random field as salt for the codeMaster
     codeMasterSalt = Field.random();
 
+    // Create codeBreaker keys & derive ID
     codeBreakerKey = PrivateKey.random();
     codeBreakerPubKey = codeBreakerKey.toPublicKey();
     codeBreakerId = Poseidon.hash(codeBreakerPubKey.toFields());
   });
-  async function testInvalidCreateGame(
+  async function expectCreateGameToFail(
     combination: number[],
     expectedErrorMessage?: string
   ) {
@@ -56,7 +65,7 @@ describe('Mastermind ZkProgram Tests', () => {
 
     await expect(gameCreation).rejects.toThrowError(expectedErrorMessage);
   }
-  async function testInvalidGuess(
+  async function expectGuessToFail(
     guess: number[],
     expectedErrorMessage?: string,
     signerKey = codeBreakerKey
@@ -81,7 +90,7 @@ describe('Mastermind ZkProgram Tests', () => {
 
     await expect(makeGuess).rejects.toThrowError(expectedErrorMessage);
   }
-  async function testInvalidClue(
+  async function expectGiveClueToFail(
     combination: number[],
     expectedErrorMessage?: string,
     signerKey = codeMasterKey,
@@ -117,12 +126,12 @@ describe('Mastermind ZkProgram Tests', () => {
   describe('createGame method', () => {
     it('should reject codeMaster with invalid secret combination: second digit is 0', async () => {
       const expectedErrorMessage = 'Combination digit 2 should not be zero!';
-      await testInvalidCreateGame([5, 0, 4, 6], expectedErrorMessage);
+      await expectCreateGameToFail([5, 0, 4, 6], expectedErrorMessage);
     });
 
     it('should reject codeMaster with invalid secret combination: third digit is not unique', async () => {
       const expectedErrorMessage = 'Combination digit 3 is not unique!';
-      await testInvalidCreateGame([2, 3, 2, 9], expectedErrorMessage);
+      await expectCreateGameToFail([2, 3, 2, 9], expectedErrorMessage);
     });
 
     it('should create a game successfully', async () => {
@@ -161,18 +170,18 @@ describe('Mastermind ZkProgram Tests', () => {
   describe('makeGuess method tests: first guess', () => {
     it('should reject codeBreaker with invalid guess combination: fouth digit is 0', async () => {
       const expectedErrorMessage = 'Combination digit 4 should not be zero!';
-      await testInvalidGuess([6, 9, 3, 0], expectedErrorMessage);
+      await expectGuessToFail([6, 9, 3, 0], expectedErrorMessage);
     });
 
     it('should reject codeBreaker with invalid guess combination: second digit is not unique', async () => {
       const expectedErrorMessage = 'Combination digit 2 is not unique!';
-      await testInvalidGuess([1, 1, 2, 9], expectedErrorMessage);
+      await expectGuessToFail([1, 1, 2, 9], expectedErrorMessage);
     });
 
     it('should reject giveClue in the wrong turn', async () => {
       const expectedErrorMessage =
         'Please wait for the codeBreaker to make a guess!';
-      await testInvalidClue([1, 2, 3, 4], expectedErrorMessage);
+      await expectGiveClueToFail([1, 2, 3, 4], expectedErrorMessage);
     });
 
     it('codeBreaker should make a guess successfully', async () => {
@@ -211,7 +220,7 @@ describe('Mastermind ZkProgram Tests', () => {
       const expectedErrorMessage =
         'Please wait for the codeMaster to give you a clue!';
 
-      await testInvalidGuess([2, 3, 4, 5], expectedErrorMessage);
+      await expectGuessToFail([2, 3, 4, 5], expectedErrorMessage);
     });
   });
 
@@ -219,7 +228,7 @@ describe('Mastermind ZkProgram Tests', () => {
     it('should reject any caller other than the codeMaster', async () => {
       const expectedErrorMessage =
         'Only the codeMaster of this game is allowed to give clue!';
-      await testInvalidClue(
+      await expectGiveClueToFail(
         [1, 2, 3, 4],
         expectedErrorMessage,
         PrivateKey.random()
@@ -230,7 +239,7 @@ describe('Mastermind ZkProgram Tests', () => {
       const differentSalt = Field.random();
       const expectedErrorMessage =
         'The secret combination is not compliant with the initial hash from game creation!';
-      await testInvalidClue(
+      await expectGiveClueToFail(
         [1, 2, 3, 4],
         expectedErrorMessage,
         codeMasterKey,
@@ -241,7 +250,7 @@ describe('Mastermind ZkProgram Tests', () => {
     it('should reject codeMaster with non-compliant secret combination', async () => {
       const expectedErrorMessage =
         'The secret combination is not compliant with the initial hash from game creation!';
-      await testInvalidClue([1, 5, 3, 4], expectedErrorMessage);
+      await expectGiveClueToFail([1, 5, 3, 4], expectedErrorMessage);
     });
 
     it('codeMaster should give clue successfully', async () => {
@@ -280,14 +289,14 @@ describe('Mastermind ZkProgram Tests', () => {
     it('should reject the codeMaster from calling this method out of sequence', async () => {
       const expectedErrorMessage =
         'Please wait for the codeBreaker to make a guess!';
-      await testInvalidClue([1, 2, 3, 4], expectedErrorMessage);
+      await expectGiveClueToFail([1, 2, 3, 4], expectedErrorMessage);
     });
   });
 
   describe('second guess', () => {
     it('should reject any caller other than the codeBreaker', async () => {
       const expectedErrorMessage = 'You are not the codeBreaker of this game!';
-      await testInvalidGuess(
+      await expectGuessToFail(
         [1, 4, 7, 2],
         expectedErrorMessage,
         PrivateKey.random()
@@ -325,7 +334,7 @@ describe('Mastermind ZkProgram Tests', () => {
     it('should reject the codebraker from calling this method out of sequence', async () => {
       const expectedErrorMessage =
         'Please wait for the codeMaster to give you a clue!';
-      await testInvalidGuess([1, 2, 4, 8], expectedErrorMessage);
+      await expectGuessToFail([1, 2, 4, 8], expectedErrorMessage);
     });
   });
 
@@ -434,13 +443,13 @@ describe('Mastermind ZkProgram Tests', () => {
     it('should reject next guess: secret is already solved', async () => {
       const expectedErrorMessage =
         'You have already solved the secret combination!';
-      await testInvalidGuess([1, 2, 3, 4], expectedErrorMessage);
+      await expectGuessToFail([1, 2, 3, 4], expectedErrorMessage);
     });
 
     it('should reject next clue: secret is already solved', async () => {
       const expectedErrorMessage =
         'Please wait for the codeBreaker to make a guess!';
-      await testInvalidClue([2, 2, 2, 2], expectedErrorMessage);
+      await expectGiveClueToFail([2, 2, 2, 2], expectedErrorMessage);
     });
   });
 });

--- a/src/test/testUtils.ts
+++ b/src/test/testUtils.ts
@@ -1,0 +1,75 @@
+import { Field, PrivateKey, Signature } from 'o1js';
+import { compressCombinationDigits } from '../utils';
+import { StepProgram, StepProgramProof } from '../stepProgram';
+
+/**
+ * Creates a new game and returns the resulting proof.
+ */
+export const StepProgramCreateGame = async (
+  secret: number[],
+  salt: Field,
+  codeMasterKey: PrivateKey
+): Promise<StepProgramProof> => {
+  const unseparatedSecret = compressCombinationDigits(secret.map(Field));
+
+  const { proof } = await StepProgram.createGame(
+    {
+      authPubKey: codeMasterKey.toPublicKey(),
+      authSignature: Signature.create(codeMasterKey, [unseparatedSecret, salt]),
+    },
+    unseparatedSecret,
+    salt
+  );
+  return proof;
+};
+
+/**
+ * Makes a guess and returns the updated proof.
+ */
+export const StepProgramMakeGuess = async (
+  prevProof: StepProgramProof,
+  guess: number[],
+  codeBreakerKey: PrivateKey
+): Promise<StepProgramProof> => {
+  const unseparatedGuess = compressCombinationDigits(guess.map(Field));
+  const { proof } = await StepProgram.makeGuess(
+    {
+      authPubKey: codeBreakerKey.toPublicKey(),
+      authSignature: Signature.create(codeBreakerKey, [
+        unseparatedGuess,
+        Field.from(prevProof.publicOutput.turnCount.toBigInt()),
+      ]),
+    },
+    prevProof,
+    unseparatedGuess
+  );
+  return proof;
+};
+
+/**
+ * Gives a clue and returns the updated proof.
+ */
+export const StepProgramGiveClue = async (
+  prevProof: StepProgramProof,
+  combination: number[],
+  salt: Field,
+  codeMasterKey: PrivateKey
+): Promise<StepProgramProof> => {
+  const unseparatedCombination = compressCombinationDigits(
+    combination.map(Field)
+  );
+  const { proof } = await StepProgram.giveClue(
+    {
+      authPubKey: codeMasterKey.toPublicKey(),
+      authSignature: Signature.create(codeMasterKey, [
+        unseparatedCombination,
+        salt,
+        Field.from(prevProof.publicOutput.turnCount.toBigInt()),
+      ]),
+    },
+    prevProof,
+    unseparatedCombination,
+    salt
+  );
+  return proof;
+};

--- a/src/test/utils.test.ts
+++ b/src/test/utils.test.ts
@@ -1,10 +1,13 @@
 import {
+  compressRewardAndFinalizeSlot,
   compressTurnCountMaxAttemptSolved,
+  separateTurnCountAndMaxAttemptSolved,
+  separateRewardAndFinalizeSlot,
   getClueFromGuess,
   separateCombinationDigits,
   validateCombination,
 } from '../utils';
-import { Field } from 'o1js';
+import { Field, UInt32, UInt64 } from 'o1js';
 
 describe('Provable utilities - unit tests', () => {
   describe('Tests for separateCombinationDigits function', () => {
@@ -167,7 +170,9 @@ describe('Provable utilities - unit tests', () => {
 
       expect(clue).toEqual([1, 1, 1, 1].map(Field));
     });
+  });
 
+  describe('Tests for compressTurnCountMaxAttemptSolved function', () => {
     it('should compress the turn count, max attempt, and solved flag into a single Field value', () => {
       const turnCount = Field(5);
       const maxAttempts = Field(10);
@@ -216,9 +221,30 @@ describe('Provable utilities - unit tests', () => {
       const compressedValue = Field(51001);
       const expectedDigits = [5, 10, 1].map(Field);
 
-      expect(compressTurnCountMaxAttemptSolved(expectedDigits)).toEqual(
-        compressedValue
+      expect(separateTurnCountAndMaxAttemptSolved(compressedValue)).toEqual(
+        expectedDigits
       );
+    });
+  });
+
+  describe('Tests for compressRewardAndFinalizeSlot function', () => {
+    const rewardAmount = UInt64.from(100);
+    const finalizeSlot = UInt32.from(10);
+    it('should compress the reward amount and finalize slot into a single Field value', () => {
+      const expectedValue = Field(2 ** 32 * 100 + 10);
+      expect(compressRewardAndFinalizeSlot(rewardAmount, finalizeSlot)).toEqual(
+        expectedValue
+      );
+    });
+
+    it('should successfully separate the compressed value into reward amount and finalize slot', () => {
+      const compressedValue = Field(2 ** 32 * 100 + 10);
+
+      const separatedRewardAndFinalizeSlot =
+        separateRewardAndFinalizeSlot(compressedValue);
+
+      expect(separatedRewardAndFinalizeSlot.finalizeSlot).toEqual(finalizeSlot);
+      expect(separatedRewardAndFinalizeSlot.rewardAmount).toEqual(rewardAmount);
     });
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -207,6 +207,12 @@ function separateTurnCountAndMaxAttemptSolved(value: Field) {
   return digits;
 }
 
+/**
+ * Combines the reward amount and finalize slot into a single Field value.
+ * @param rewardAmount - The amount of reward in `UInt64`.
+ * @param finalizeSlot - The slot at which the game will finalize in `UInt32`.
+ * @returns - The combined Field element representing the compressed reward amount and finalize slot.
+ */
 function compressRewardAndFinalizeSlot(
   rewardAmount: UInt64,
   finalizeSlot: UInt32
@@ -214,6 +220,12 @@ function compressRewardAndFinalizeSlot(
   return rewardAmount.value.mul(2 ** 32).add(finalizeSlot.value);
 }
 
+/**
+ * Separates the reward amount and finalize slot from a single Field value.
+ *
+ * @param value - The Field value to be separated into reward amount and finalize slot.
+ * @returns - An object containing the separated reward amount and finalize slot.
+ */
 function separateRewardAndFinalizeSlot(value: Field) {
   const digits = Provable.witness(Provable.Array(UInt32, 3), () => {
     const num = value.toBigInt();


### PR DESCRIPTION
## Changes
- Removed `@method` decorator from internal functions [ea1b1c8](https://github.com/navigators-exploration-team/recursive-mastermind-zkApp/pull/1/commits/ea1b1c8d60c3b1b3e2cc24e8940709b2bd19c7b0)
- Merged `claimCodeBreakerReward` and `claimCodeMasterReward` functions into `claimReward`, it's only callable by code breaker or code master itself whenever they won the game after finalization [1e77913](https://github.com/navigators-exploration-team/recursive-mastermind-zkApp/pull/1/commits/1e7791375e5f9713360f9bcd1dc865430b1d407f)
- Removed internal `getContractBalance` method and `finalizeSlot` state changed to `rewardFinalizeSlot`. This way when code master creates a game with arbitrary rewards, the amount is compressed along with finalize slot and stored  in `rewardFinalizeSlot`. Code breaker can accept this game only after depositing same amount of Mina as code master.
- Added helper functions `compressRewardAndFinalizeSlot` and `separateRewardAndFinalizeSlot` to store `UInt64` and `UInt32` into single field. [f3454f8](https://github.com/navigators-exploration-team/recursive-mastermind-zkApp/pull/1/commits/f3454f8ac8aab43995c9770e5b556bf3aef67e55)
- `receive: Permissions.proof()` removed due to deposited reward amount is already stored on chain.
- New benchmark results for both NodeJS and browser environments. [c8a80e9](https://github.com/navigators-exploration-team/recursive-mastermind-zkApp/pull/1/commits/c8a80e9d98776ca10170daecb72896e1554da8db)
[Benchmark Report](https://github.com/navigators-exploration-team/recursive-mastermind-zkApp/blob/c8a80e9d98776ca10170daecb72896e1554da8db/src/benchmark/benchmark.md)

## Improvements
- Simplified naming and more comments are added for increased readability and educational content.
-  Removed redundant unit test cases, and repetitive computations.
- `StepProgramProof` generation moved to reusable functions to increase code readability and reusability. [d64caa1](https://github.com/navigators-exploration-team/recursive-mastermind-zkApp/pull/1/commits/d64caa1fa7cc7060783fb4b068c9367ec4c9050f)
- Merged `createGame` method into `initGame` to reduce needed tx and gas fee. [f72d817](https://github.com/navigators-exploration-team/recursive-mastermind-zkApp/pull/1/commits/f72d817a1c58b716d05dafd1d6370f112d6a4ee5)

## Fixed
- Previously browser environment benchmarks does not able to finish tasks due to blocked event loop, now it make calculations in web workers. [2b2e031](https://github.com/navigators-exploration-team/recursive-mastermind-zkApp/pull/1/commits/2b2e031e45d73e24edf63f64982af2b4a0bc1c23)